### PR TITLE
Message meta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Use `url_alias`, `appdata_alias` or `header_menu_css_class` of members instead.
 
 ## FunPay Parsers 0.3.0
 
+### Changes
+
 - Members of `funpayparsers.types.enums.SubcategoryType` and `funpayparsers.types.enums.Language` now use frozen 
 dataclasses as their values instead of relying on custom `__new__` logic in Enums.
 - Accessing enum fields now requires `.value`, e.g.:
@@ -55,3 +57,18 @@ dataclasses as their values instead of relying on custom `__new__` logic in Enum
 > for type checkers like `mypy`.
 >
 > This design is currently considered a balanced trade-off between architectural purity and practical readability.
+
+
+## FunPay Parsers 0.3.1
+
+### Features
+
+- Added `@classmethod` `from_raw_source` to `FunPayObject`. Raises `NotImplementedError` by default.
+- Implemented `from_raw_source` in all page-types.
+- Added `timestamp` property to `funpayparsers.types.Message`.
+
+### Improvements
+
+- Improved ``funpayparsers.parsers.utils.parse_date_string``: added new patterns of dates.
+- Improved ``funpayparsers.parsers.utils.resolve_messages_senders``: field `send_date_text` of heading message 
+now propagates on messages below it.

--- a/funpayparsers/parsers/__init__.py
+++ b/funpayparsers/parsers/__init__.py
@@ -20,3 +20,4 @@ from .offer_previews_parser import *
 from .order_previews_parser import *
 from .private_chat_info_parser import *
 from .transaction_previews_parser import *
+from .message_meta_parser import *

--- a/funpayparsers/parsers/message_meta_parser.py
+++ b/funpayparsers/parsers/message_meta_parser.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+
+__all__ = ('MessageMetaParsingOptions', 'MessageMetaParser')
+
+
+from dataclasses import dataclass
+
+from funpayparsers.parsers.base import ParsingOptions, FunPayHTMLObjectParser
+from funpayparsers.types.enums import MessageType
+from funpayparsers.types.messages import MessageMeta
+
+
+
+@dataclass(frozen=True)
+class MessageMetaParsingOptions(ParsingOptions):
+    """Options class for ``MessageMetaParser``."""
+    ...
+
+
+class MessageMetaParser(FunPayHTMLObjectParser[MessageMeta, MessageMetaParsingOptions]):
+    """
+    Class for parsing message meta data.
+    Possible locations:
+        - On chat pages (https://funpay.com/chat/?node=<chat_id>).
+        - In runners response.
+    """
+
+    def _parse(self) -> MessageMeta:
+        parse_mapping = {
+            MessageType.NEW_ORDER: self.parse_new_order_message,
+            MessageType.ORDER_CLOSED: self.parse_order_closed_message,
+            MessageType.ORDER_CLOSED_BY_ADMIN: self.parse_order_closed_by_admin_message,
+            MessageType.ORDER_REOPENED: self.parse_order_reopened_message,
+            MessageType.ORDER_REFUNDED: self.parse_order_refunded_message,
+            MessageType.ORDER_PARTIALLY_REFUNDED: self.parse_order_partially_refunded_message,
+            MessageType.NEW_FEEDBACK: self.parse_feedback_message,
+            MessageType.FEEDBACK_CHANGED: self.parse_feedback_message,
+            MessageType.FEEDBACK_DELETED: self.parse_feedback_message,
+            MessageType.NEW_FEEDBACK_REPLY: self.parse_feedback_reply_message,
+            MessageType.FEEDBACK_REPLY_CHANGED: self.parse_feedback_reply_message,
+            MessageType.FEEDBACK_REPLY_DELETED: self.parse_feedback_reply_message,
+        }
+
+        msg_type = MessageType.get_by_message_text(self.tree.text())
+
+        if msg_type not in parse_mapping:
+            return MessageMeta(raw_source=self.raw_source, type=msg_type)
+
+        result = parse_mapping[msg_type]()
+        result.type = msg_type
+        return result
+
+    def parse_new_order_message(self) -> MessageMeta:
+        links = self.tree.css('a')
+        return MessageMeta(
+            raw_source=self.raw_source,
+            order_id=links[1].attributes['href'].split('/')[-2],  # type: ignore[union-attr]
+            order_desc=links[1].next.text()[2:],  # type: ignore[union-attr]
+            buyer_id=int(links[0].attributes['href'].split('/')[-2]),  # type: ignore[union-attr]
+            buyer_username=links[0].text(strip=True)
+        )
+
+    def parse_order_closed_message(self) -> MessageMeta:
+        links = self.tree.css('a')
+
+        return MessageMeta(
+            raw_source=self.raw_source,
+            order_id=links[1].attributes['href'].split('/')[-2],  # type: ignore[union-attr]
+            buyer_id=int(links[0].attributes['href'].split('/')[-2]),  # type: ignore[union-attr]
+            buyer_username=links[0].text(strip=True),
+            seller_id=int(links[2].attributes['href'].split('/')[-2]),  # type: ignore[union-attr]
+            seller_username=links[2].text(strip=True),
+        )
+
+    def parse_order_closed_by_admin_message(self) -> MessageMeta:
+        links = self.tree.css('a')
+
+        return MessageMeta(
+            raw_source=self.raw_source,
+            order_id=links[1].attributes['href'].split('/')[-2],  # type: ignore[union-attr]
+            admin_id=int(links[0].attributes['href'].split('/')[-2]),  # type: ignore[union-attr]
+            admin_username=links[0].text(strip=True),
+            seller_id=int(links[2].attributes['href'].split('/')[-2]),  # type: ignore[union-attr]
+            seller_username=links[2].text(strip=True),
+        )
+
+    def parse_order_reopened_message(self) -> MessageMeta:
+        links = self.tree.css('a')
+
+        return MessageMeta(
+            raw_source=self.raw_source,
+            order_id=links[0].attributes['href'].split('/')[-2],  # type: ignore[union-attr]
+        )
+
+    def parse_order_refunded_message(self) -> MessageMeta:
+        links = self.tree.css('a')
+
+        return MessageMeta(
+            raw_source=self.raw_source,
+            order_id=links[2].attributes['href'].split('/')[-2],  # type: ignore[union-attr]
+            buyer_id=int(links[1].attributes['href'].split('/')[-2]),  # type: ignore[union-attr]
+            buyer_username=links[1].text(strip=True),
+            seller_id=int(links[0].attributes['href'].split('/')[-2]),  # type: ignore[union-attr]
+            seller_username=links[0].text(strip=True),
+        )
+
+    def parse_order_partially_refunded_message(self) -> MessageMeta:
+        links = self.tree.css('a')
+
+        return MessageMeta(
+            raw_source=self.raw_source,
+            order_id=links[0].attributes['href'].split('/')[-2],  # type: ignore[union-attr]
+        )
+
+    def parse_feedback_message(self) -> MessageMeta:
+        links = self.tree.css('a')
+
+        return MessageMeta(
+            raw_source=self.raw_source,
+            order_id=links[1].attributes['href'].split('/')[-2],  # type: ignore[union-attr]
+            buyer_id=int(links[0].attributes['href'].split('/')[-2]),  # type: ignore[union-attr]
+            buyer_username=links[0].text(strip=True),
+        )
+
+    def parse_feedback_reply_message(self) -> MessageMeta:
+        links = self.tree.css('a')
+
+        return MessageMeta(
+            raw_source=self.raw_source,
+            order_id=links[1].attributes['href'].split('/')[-2],  # type: ignore[union-attr]
+            seller_id=int(links[0].attributes['href'].split('/')[-2]),  # type: ignore[union-attr]
+            seller_username=links[0].text(strip=True),
+        )

--- a/funpayparsers/types/messages.py
+++ b/funpayparsers/types/messages.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 
-__all__ = ('Message',)
+__all__ = ('Message', 'MessageMeta')
 
 from dataclasses import field, dataclass
 
@@ -11,16 +11,37 @@ from funpayparsers.types.common import UserBadge
 
 
 @dataclass
-class MessageMeta:
-    def __init__(self, message: Message):
-        self._order_id: str | None = None
-        self._order_desc: str | None = None
-        self._seller_id: int | None = None
-        self._seller_username: str | None = None
-        self._buyer_id: int | None = None
-        self._buyer_username: str | None = None
-        self._admin_id: int | None = None
-        self._admin_username: str | None = None
+class MessageMeta(FunPayObject):
+    """
+    Represents a message meta info.
+    """
+
+    type: MessageType = MessageType.NON_SYSTEM
+    """Message type."""
+
+    order_id: str | None = None
+    """Mentioned order ID."""
+
+    order_desc: str | None = None
+    """Mentioned order description."""
+
+    seller_id: int | None = None
+    """Mentioned seller ID."""
+
+    seller_username: str | None = None
+    """Mentioned seller username."""
+
+    buyer_id: int | None = None
+    """Mentioned buyer ID."""
+
+    buyer_username: str | None = None
+    """Mentioned buyer username."""
+
+    admin_id: int | None = None
+    """Mentioned admin ID."""
+
+    admin_username: str | None = None
+    """Mentioned admin username."""
 
 
 @dataclass
@@ -90,25 +111,10 @@ class Message(FunPayObject):
     Context key: ``chat_name``.
     """
 
-    _type_cache: tuple[str | None, MessageType] | None = field(
-        init=False, repr=False, compare=False, hash=False, default=None
-    )
-
-    @property
-    def type(self) -> MessageType:
-        if self._type_cache is not None:
-            if self._type_cache[0] == self.text:
-                return self._type_cache[1]
-
-        if not self.text:
-            return MessageType.NON_SYSTEM
-
-        if self.sender_id not in [0, 500]:
-            return MessageType.NON_SYSTEM
-
-        msg_type = MessageType.get_by_message_text(self.text)
-        self._type_cache = (self.text, msg_type)
-        return msg_type
+    meta: MessageMeta
+    """
+    Message meta info (message type, mentioned users / order).
+    """
 
     @property
     def timestamp(self) -> int:

--- a/funpayparsers/types/messages.py
+++ b/funpayparsers/types/messages.py
@@ -11,6 +11,19 @@ from funpayparsers.types.common import UserBadge
 
 
 @dataclass
+class MessageMeta:
+    def __init__(self, message: Message):
+        self._order_id: str | None = None
+        self._order_desc: str | None = None
+        self._seller_id: int | None = None
+        self._seller_username: str | None = None
+        self._buyer_id: int | None = None
+        self._buyer_username: str | None = None
+        self._admin_id: int | None = None
+        self._admin_username: str | None = None
+
+
+@dataclass
 class Message(FunPayObject):
     """Represents a message from any FunPay chat (private or public)."""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "funpayparsers"
 description = "Set of parsers for FunPay website."
 keywords = ["funpay", "parser", "bot", "api", "funpayapi", "funpayparser", "funpaybot"]
-version = "0.3.0"
+version = "0.3.1"
 readme = "README.md"
 license = "MIT"
 

--- a/tests/parsers_test/messages_parser_test.py
+++ b/tests/parsers_test/messages_parser_test.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from funpayparsers.types import Message, UserBadge
+from funpayparsers.types import Message, MessageMeta, UserBadge
+from funpayparsers.types.enums import MessageType
 from funpayparsers.parsers.messages_parser import MessagesParser, MessagesParsingOptions
 
 
 OPTIONS = MessagesParsingOptions(empty_raw_source=True)
-
 
 heading_message_html = """<div class="chat-msg-item chat-msg-with-head" id="message-12345">
     <div class="chat-message">
@@ -19,18 +19,20 @@ heading_message_html = """<div class="chat-msg-item chat-msg-with-head" id="mess
     </div>
 </div>"""
 
-heading_message_obj = Message(raw_source='',
-                              id=12345,
-                              is_heading=True,
-                              sender_id=54321,
-                              sender_username='Username',
-                              badge=None,
-                              send_date_text='26 мая, 11:21:41',
-                              text='MessageText',
-                              image_url=None,
-                              chat_id=None,
-                              chat_name=None
-                              )
+heading_message_obj = Message(
+    raw_source='',
+    id=12345,
+    is_heading=True,
+    sender_id=54321,
+    sender_username='Username',
+    badge=None,
+    send_date_text='26 мая, 11:21:41',
+    text='MessageText',
+    image_url=None,
+    chat_id=None,
+    chat_name=None,
+    meta=MessageMeta(raw_source='')
+)
 
 
 non_heading_message_html = """<div class="chat-msg-item" id="message-12346">
@@ -41,18 +43,20 @@ non_heading_message_html = """<div class="chat-msg-item" id="message-12346">
     </div>
 </div>"""
 
-non_heading_message_obj = Message(raw_source='',
-                                  id=12346,
-                                  is_heading=False,
-                                  sender_id=None,
-                                  sender_username=None,
-                                  badge=None,
-                                  send_date_text=None,
-                                  text='MessageText',
-                                  image_url=None,
-                                  chat_id=None,
-                                  chat_name=None
-                                  )
+non_heading_message_obj = Message(
+    raw_source='',
+    id=12346,
+    is_heading=False,
+    sender_id=None,
+    sender_username=None,
+    badge=None,
+    send_date_text=None,
+    text='MessageText',
+    image_url=None,
+    chat_id=None,
+    chat_name=None,
+    meta=MessageMeta(raw_source='')
+)
 
 
 notification_message_html = """<div class="chat-msg-item chat-msg-with-head" id="message-12347">
@@ -85,7 +89,16 @@ notification_message_obj = Message(
         text='оповещение'
     ),
     chat_id=None,
-    chat_name=None
+    chat_name=None,
+    meta=MessageMeta(
+        raw_source='',
+        type=MessageType.ORDER_REFUNDED,
+        seller_id=10,
+        seller_username='SellerUsername',
+        buyer_id=54321,
+        buyer_username='BuyerUsername',
+        order_id='AAAAAAAA'
+    )
 )
 
 
@@ -103,7 +116,8 @@ multiple_messages_obj = [
         text='MessageText',
         image_url=None,
         chat_id=None,
-        chat_name=None
+        chat_name=None,
+        meta=MessageMeta(raw_source='')
     )
 ]
 

--- a/tests/parsers_test/resolve_messages_sender_test.py
+++ b/tests/parsers_test/resolve_messages_sender_test.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from funpayparsers.types import Message, UserBadge
+from funpayparsers.types import Message, UserBadge, MessageMeta
 from funpayparsers.parsers.utils import resolve_messages_senders
 
 
@@ -25,7 +25,8 @@ processed_messages = [
         text='MessageText1',
         image_url=None,
         chat_id=None,
-        chat_name=None
+        chat_name=None,
+        meta=MessageMeta(raw_source='')
     ),
     Message(
         raw_source='',
@@ -38,7 +39,8 @@ processed_messages = [
         text='MessageText2',
         image_url=None,
         chat_id=None,
-        chat_name=None
+        chat_name=None,
+        meta=MessageMeta(raw_source='')
     )
 ]
 
@@ -57,7 +59,8 @@ def original_messages():
             text='MessageText1',
             image_url=None,
             chat_id=None,
-            chat_name=None
+            chat_name=None,
+            meta=MessageMeta(raw_source='')
         ),
         Message(
             raw_source='',
@@ -70,7 +73,8 @@ def original_messages():
             text='MessageText2',
             image_url=None,
             chat_id=None,
-            chat_name=None
+            chat_name=None,
+            meta=MessageMeta(raw_source='')
         )
     ]
 


### PR DESCRIPTION
- Added new object `funpayparses.types.messages.MessageMeta` and related parser 
`funpayparsers.parsers.message_meta_parser.MessageMetaParser`. `MessageMeta` contains meta info about message, such is
message type and mentioned seller / buyer / admin / order (if it is system message). `MessageMetaParser` accepts inner
html of message (inner html of `div.chat-msg-text`) and returns `MessageMeta` object.

- `funpayparsers.types.messages.Message.type` moved to `funpayparsers.types.messages.Message.meta.type`

- `funpayparsers.parsers.messages_parser.MessagesParser` doesn't strip message texts anymore.