### PR TITLE
SRAS Info page parser

### DIFF
--- a/funpayparsers/parsers/page_parsers/__init__.py
+++ b/funpayparsers/parsers/page_parsers/__init__.py
@@ -10,3 +10,4 @@ from .settings_page_parser import *
 from .my_offers_page_parser import *
 from .subcategory_page_parser import *
 from .transactions_page_parser import *
+from .sras_info_page_parser import *

--- a/funpayparsers/parsers/page_parsers/sras_info_page_parser.py
+++ b/funpayparsers/parsers/page_parsers/sras_info_page_parser.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+
+__all__ = ('SrasInfoPageParser', 'SrasInfoPageParsingOptions')
+
+import re
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+from selectolax.lexbor import LexborNode
+
+from funpayparsers.types.sras import SrasSectionRestriction
+from funpayparsers.types.enums import SubcategoryType
+from funpayparsers.parsers.base import ParsingOptions, FunPayHTMLObjectParser
+from funpayparsers.parsers.appdata_parser import AppDataParser, AppDataParsingOptions
+from funpayparsers.parsers.page_header_parser import (
+    PageHeaderParser,
+    PageHeaderParsingOptions,
+)
+from funpayparsers.types.pages.sras_info_page import SrasInfoPage
+
+
+RATING_RE = re.compile(r'(\d+)')
+
+
+@dataclass(frozen=True)
+class SrasInfoPageParsingOptions(ParsingOptions):
+    """Options class for ``SrasInfoPageParser``."""
+
+    page_header_parsing_options: PageHeaderParsingOptions = PageHeaderParsingOptions()
+    """
+    Options instance for ``PageHeaderParser``, which is used by ``SrasInfoPageParser``.
+    """
+
+    app_data_parsing_options: AppDataParsingOptions = AppDataParsingOptions()
+    """
+    Options instance for ``AppDataParser``, which is used by ``SrasInfoPageParser``.
+    """
+
+
+class SrasInfoPageParser(FunPayHTMLObjectParser[SrasInfoPage, SrasInfoPageParsingOptions]):
+    """Parser for SRAS info page (`https://funpay.com/sras/info`)."""
+
+    def _parse(self) -> SrasInfoPage:
+        header_tag = self.tree.css_first('header')
+        body_tag = self.tree.css_first('body')
+        content_tag = self.tree.css_first('div.page-content-full')
+
+        if header_tag is None or body_tag is None or content_tag is None:
+            raise LookupError('Unable to locate required SRAS page elements.')
+
+        restrictions: dict[SubcategoryType, dict[int, SrasSectionRestriction]] = {}
+
+        for row in content_tag.css('table tbody tr'):
+            restriction = self._parse_restriction(row)
+            by_type = restrictions.setdefault(restriction.subcategory_type, {})
+            by_type[restriction.subcategory_id] = restriction
+
+        return SrasInfoPage(
+            raw_source=self.raw_source,
+            header=PageHeaderParser(
+                header_tag.html or '',
+                options=self.options.page_header_parsing_options,
+            ).parse(),
+            app_data=AppDataParser(
+                body_tag.attributes.get('data-app-data') or '',
+                options=self.options.app_data_parsing_options,
+            ).parse(),
+            restrictions=restrictions,
+        )
+
+    def _parse_restriction(self, row: LexborNode) -> SrasSectionRestriction:
+        cells = row.css('td')
+        if len(cells) < 2:
+            raise LookupError('SRAS restriction row must have two columns.')
+
+        link = cells[0].css_first('a')
+        if link is None:
+            raise LookupError('SRAS restriction row must contain a link.')
+
+        href = link.attributes.get('href')
+        if not href:
+            raise LookupError('SRAS restriction link must contain href.')
+
+        subcategory_type = SubcategoryType.from_url(href)
+        subcategory_id = self._parse_subcategory_id(href)
+        max_rating = self._parse_max_rating(cells[1].text(strip=True))
+
+        return SrasSectionRestriction(
+            raw_source=row.html or '',
+            subcategory_id=subcategory_id,
+            subcategory_type=subcategory_type,
+            max_rating=max_rating,
+        )
+
+    def _parse_subcategory_id(self, href: str) -> int:
+        path_parts = [part for part in urlparse(href).path.split('/') if part]
+        if not path_parts:
+            raise LookupError('Unable to parse SRAS subcategory id from href.')
+        return int(path_parts[-1])
+
+    def _parse_max_rating(self, text: str) -> int:
+        match = RATING_RE.search(text)
+        if match is None:
+            raise LookupError('Unable to parse SRAS max rating.')
+        return int(match.group(1))

--- a/funpayparsers/parsers/page_parsers/sras_info_page_parser.py
+++ b/funpayparsers/parsers/page_parsers/sras_info_page_parser.py
@@ -46,9 +46,6 @@ class SrasInfoPageParser(FunPayHTMLObjectParser[SrasInfoPage, SrasInfoPageParsin
         body_tag = self.tree.css_first('body')
         content_tag = self.tree.css_first('div.page-content-full')
 
-        if header_tag is None or body_tag is None or content_tag is None:
-            raise LookupError('Unable to locate required SRAS page elements.')
-
         restrictions: dict[SubcategoryType, dict[int, SrasSectionRestriction]] = {}
 
         for row in content_tag.css('table tbody tr'):
@@ -71,16 +68,8 @@ class SrasInfoPageParser(FunPayHTMLObjectParser[SrasInfoPage, SrasInfoPageParsin
 
     def _parse_restriction(self, row: LexborNode) -> SrasSectionRestriction:
         cells = row.css('td')
-        if len(cells) < 2:
-            raise LookupError('SRAS restriction row must have two columns.')
-
         link = cells[0].css_first('a')
-        if link is None:
-            raise LookupError('SRAS restriction row must contain a link.')
-
-        href = link.attributes.get('href')
-        if not href:
-            raise LookupError('SRAS restriction link must contain href.')
+        href = link.attributes['href']  # type: ignore[union-attr]
 
         subcategory_type = SubcategoryType.from_url(href)
         subcategory_id = self._parse_subcategory_id(href)
@@ -95,12 +84,7 @@ class SrasInfoPageParser(FunPayHTMLObjectParser[SrasInfoPage, SrasInfoPageParsin
 
     def _parse_subcategory_id(self, href: str) -> int:
         path_parts = [part for part in urlparse(href).path.split('/') if part]
-        if not path_parts:
-            raise LookupError('Unable to parse SRAS subcategory id from href.')
         return int(path_parts[-1])
 
     def _parse_max_rating(self, text: str) -> int:
-        match = RATING_RE.search(text)
-        if match is None:
-            raise LookupError('Unable to parse SRAS max rating.')
-        return int(match.group(1))
+        return int(RATING_RE.search(text).group(1))  # type: ignore[union-attr]

--- a/funpayparsers/types/__init__.py
+++ b/funpayparsers/types/__init__.py
@@ -13,3 +13,4 @@ from .messages import *
 from .settings import *
 from .categories import *
 from .common_page_elements import *
+from .sras import *

--- a/funpayparsers/types/pages/__init__.py
+++ b/funpayparsers/types/pages/__init__.py
@@ -11,3 +11,4 @@ from .settings_page import *
 from .my_offers_page import *
 from .subcategory_page import *
 from .transactions_page import *
+from .sras_info_page import *

--- a/funpayparsers/types/pages/sras_info_page.py
+++ b/funpayparsers/types/pages/sras_info_page.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+
+__all__ = ('SrasInfoPage',)
+
+from typing import TYPE_CHECKING
+from dataclasses import dataclass
+
+from funpayparsers.types.sras import SrasSectionRestriction
+from funpayparsers.types.enums import SubcategoryType
+from funpayparsers.types.pages.base import FunPayPage
+
+
+if TYPE_CHECKING:
+    from funpayparsers.parsers.page_parsers.sras_info_page_parser import (
+        SrasInfoPageParsingOptions,
+    )
+
+
+@dataclass
+class SrasInfoPage(FunPayPage):
+    """Represents the SRAS info page (`https://funpay.com/sras/info`)."""
+
+    restrictions: dict[SubcategoryType, dict[int, SrasSectionRestriction]]
+    """Restrictions grouped by subcategory type and subcategory ID."""
+
+    @classmethod
+    def from_raw_source(
+        cls, raw_source: str, options: SrasInfoPageParsingOptions | None = None
+    ) -> SrasInfoPage:
+        from funpayparsers.parsers.page_parsers.sras_info_page_parser import (
+            SrasInfoPageParser,
+            SrasInfoPageParsingOptions,
+        )
+
+        options = options or SrasInfoPageParsingOptions()
+        return SrasInfoPageParser(raw_source=raw_source, options=options).parse()

--- a/funpayparsers/types/sras.py
+++ b/funpayparsers/types/sras.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+
+__all__ = ('SrasSectionRestriction',)
+
+from dataclasses import dataclass
+
+from funpayparsers.types.base import FunPayObject
+from funpayparsers.types.enums import SubcategoryType
+
+
+@dataclass
+class SrasSectionRestriction(FunPayObject):
+    """Represents a SRAS restriction for a specific subcategory."""
+
+    subcategory_id: int
+    """Subcategory ID."""
+
+    subcategory_type: SubcategoryType
+    """Subcategory type."""
+
+    max_rating: int
+    """Maximum allowed seller rating in this subcategory."""


### PR DESCRIPTION
## Summary

Add parser support for `https://funpay.com/sras/info`.

This change introduces a dedicated SRAS page model and parser that extract seller rating restrictions grouped by subcategory type and subcategory ID.

## What changed

- added `SrasSectionRestriction` model
- added `SrasInfoPage` page model
- added `SrasInfoPageParser`
- exported the new types and parser through package `__init__` modules

## Parsed structure

The parser returns restrictions in the following shape:

```python
dict[SubcategoryType, dict[int, SrasSectionRestriction]]